### PR TITLE
Make package PEP 561 compliant

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+prune asset
+global-include *.pyi
+global-include *.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ python_requires = >=3.6
 package_dir =
   = lib
 packages = find:
+include_package_data = True
 zip_safe = False
 
 # These are required during `setup.py` run:
@@ -75,6 +76,11 @@ rich =
 
 [options.packages.find]
 where = lib
+
+[options.package_data]
+subprocess_tee =
+    *.typed
+    *.pyi
 
 [tool:pytest]
 addopts = --doctest-modules --durations 10 --color=yes


### PR DESCRIPTION
Fixes issue where users of this library may get error from mypy about not being able to find type information.

Related: https://github.com/python/mypy/pull/9684