### PR TITLE
There is no need for a 'rich' extra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,8 +72,6 @@ test =
     pytest-plus
     pytest-xdist>=1.29.0
     pytest>=6.1.0
-rich =
-    enrich >= 9.5.1
 
 [options.packages.find]
 where = lib


### PR DESCRIPTION
And there is no enrich package version >= 9.5.1 yet.