### PR TITLE
Increase asyncio.create_subprocess_shell limit

### DIFF
--- a/lib/subprocess_tee/__init__.py
+++ b/lib/subprocess_tee/__init__.py
@@ -44,8 +44,11 @@ async def _stream_subprocess(args: str, **kwargs: Any) -> CompletedProcess:
         if arg in kwargs:
             platform_settings[arg] = kwargs[arg]
 
+    # Some users are reporting that default (undocumented) limit 64k is too
+    # low
     process = await asyncio.create_subprocess_shell(
         args,
+        limit=1024 * 512,
         stdin=kwargs.get("stdin", False),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,


### PR DESCRIPTION

Some users are reaching the limit of the subprocess buffers with error:
"Separator is not found, and chunk exceed the limit"

Increase it to 512k (lower values seems to be not big enough for
the reported case).

Signed-off-by: Arnaud Patard <apatard@hupstream.com>