### PR TITLE
Assure returned stderr matches one from subprocess.run

### DIFF
--- a/src/subprocess_tee/__init__.py
+++ b/src/subprocess_tee/__init__.py
@@ -90,11 +90,19 @@ async def _stream_subprocess(args: str, **kwargs: Any) -> CompletedProcess:
 
     # We need to be sure we keep the stdout/stderr output identical with
     # the ones procued by subprocess.run(), at least when in text mode.
+    check = kwargs.get("check", False)
+    stdout = None if check else ""
+    stderr = None if check else ""
+    if out:
+        stdout = os.linesep.join(out) + os.linesep
+    if err:
+        stderr = os.linesep.join(err) + os.linesep
+
     return CompletedProcess(
         args=args,
         returncode=await process.wait(),
-        stdout=(os.linesep.join(out) + os.linesep) if out else None,
-        stderr=(os.linesep.join(err) + os.linesep) if err else "",
+        stdout=stdout,
+        stderr=stderr,
     )
 
 

--- a/src/subprocess_tee/test/test_unit.py
+++ b/src/subprocess_tee/test/test_unit.py
@@ -113,6 +113,7 @@ def test_run_with_check_raise() -> None:
     assert ours.value.cmd == original.value.cmd
     assert ours.value.output == original.value.output
     assert ours.value.stdout == original.value.stdout
+    assert ours.value.stderr == original.value.stderr
 
 
 def test_run_with_check_pass() -> None:
@@ -122,3 +123,4 @@ def test_run_with_check_pass() -> None:
     assert ours.returncode == original.returncode
     assert ours.args == original.args
     assert ours.stdout == original.stdout
+    assert ours.stderr == original.stderr


### PR DESCRIPTION
Apparently python subprocess run return different values for stderr
when it does raise instead of when it returns CompletedProcess.

This assures our method matches Python behavior, so users can easily
use it as a drop-in alternative.