### PR TITLE
Avoid attempt to write to wrong pipe object

### DIFF
--- a/src/subprocess_tee/__init__.py
+++ b/src/subprocess_tee/__init__.py
@@ -74,7 +74,7 @@ async def _stream_subprocess(args: str, **kwargs: Any) -> CompletedProcess:
         def tee_func(line: bytes, sink: List[str], pipe: Optional[Any]) -> None:
             line_str = line.decode("utf-8").rstrip()
             sink.append(line_str)
-            if not kwargs.get("quiet", False):
+            if not kwargs.get("quiet", False) and hasattr(pipe, "write"):
                 print(line_str, file=pipe)
 
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
Do not attempt to write to pipe object unless it has a write
attribute. This should avoid a runtime error like:

AttributeError: 'int' object has no attribute 'write'

Observed while testing use inside ansible-compat.