### PR TITLE
Ensure output is displayed by tee

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.tox
+**/*.pyc
+.github
+build
+dist

--- a/.yamllint
+++ b/.yamllint
@@ -2,9 +2,6 @@
 # Based on ansible-lint config
 extends: default
 
-ignore: |
-  *{{cookiecutter**
-
 rules:
   braces:
     max-spaces-inside: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,22 @@ FROM alpine:latest
 # Alpine is used on purpose because it does not come with bash, and we
 # want to test that subprocess-tee works even on systems without bash shell.
 ENV BUILD_DEPS="\
+ansible-base \
+gcc \
 git \
+libffi-dev \
+make \
+musl-dev \
 python3 \
+python3-dev \
 py3-pip \
+py3-ruamel.yaml \
 "
 
 RUN \
 apk add --update --no-cache \
-${BUILD_DEPS}
+${BUILD_DEPS} && \
+pip3 install -U pip
 
 COPY . /root/code/
 WORKDIR /root/code/

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: "Test"
+      debug:
+        msg: "Past glories are poor feeding."

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,12 +66,13 @@ setup_requires =
 
 [options.extras_require]
 test =
-    enrich>=1.2.5
-    mock>=3.0.5
-    pytest-cov>=2.7.1
-    pytest-plus
-    pytest-xdist>=1.29.0
-    pytest>=6.1.0
+    enrich>=1.2.6
+    mock>=4.0.3
+    molecule>=3.4.0  # ansible is needed but no direct imports are made
+    pytest-cov>=2.12.1
+    pytest-plus>=0.2
+    pytest-xdist>=2.3.0
+    pytest>=6.2.5
 
 [options.packages.find]
 where = src

--- a/src/subprocess_tee/__init__.py
+++ b/src/subprocess_tee/__init__.py
@@ -74,8 +74,11 @@ async def _stream_subprocess(args: str, **kwargs: Any) -> CompletedProcess:
         def tee_func(line: bytes, sink: List[str], pipe: Optional[Any]) -> None:
             line_str = line.decode("utf-8").rstrip()
             sink.append(line_str)
-            if not kwargs.get("quiet", False) and hasattr(pipe, "write"):
-                print(line_str, file=pipe)
+            if not kwargs.get("quiet", False):
+                if pipe and hasattr(pipe, "write"):
+                    print(line_str, file=pipe)
+                else:
+                    print(line_str)
 
         loop = asyncio.get_event_loop()
         tasks = []

--- a/src/subprocess_tee/test/test_func.py
+++ b/src/subprocess_tee/test/test_func.py
@@ -1,0 +1,15 @@
+"""Functional tests for subprocess-tee library."""
+import subprocess
+
+
+def test_molecule() -> None:
+    """Ensures molecule does display output of its subprocesses."""
+    result = subprocess.run(
+        ["molecule", "test"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        check=False,
+    )  # type: ignore
+    assert result.returncode == 0
+    assert "Past glories are poor feeding." in result.stdout

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ minversion = 3.9.0
 envlist =
     lint
     packaging
-    py{36,37,38,39}
+    deps
+    py
 
 isolated_build = True
 
@@ -26,17 +27,20 @@ passenv =
     TERM
 setenv =
     PIP_DISABLE_VERSION_CHECK=1
-    PYTEST_REQPASS=15
+    PYTEST_REQPASS=16
     PYTHONDONTWRITEBYTECODE=1
     PYTHONUNBUFFERED=1
 commands =
     python -m pytest
+deps =
+    ansible-core
 extras =
     test
 whitelist_externals =
     find
     rm
     sh
+changedir = {toxinidir}
 
 [testenv:lint]
 description = Runs all linting tasks


### PR DESCRIPTION
Fixes error observed with molecule where pipe argument got `-1` value, causing tee functionality to not work.

Adds functional testing for subprocess-tee when used from inside molecule.

Fixes: #46