### PR TITLE
Remove mock from project's test requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,6 @@ setup_requires =
 [options.extras_require]
 test =
     enrich>=1.2.6
-    mock>=4.0.3
     molecule>=3.4.0  # ansible is needed but no direct imports are made
     pytest-cov>=2.12.1
     pytest-plus>=0.2


### PR DESCRIPTION
setup.cfg:
Remove mock, as it is not used.