### PR TITLE
Add "setuptools >= 61.0" to build system requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
 requires = [
+  # Needed for PEP 621 support
+  "setuptools >= 61.0",
   "setuptools_scm[toml] >= 7.0.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ envlist =
 isolated_build = True
 
 requires =
-    setuptools >= 41.4.0
     # 2020-resolver
     pip >= 2.20.3
 


### PR DESCRIPTION
This version is needed for PEP 621 support.