### PR TITLE
Avoid symlinked docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,1 @@
-../README.md
+{!../README.md!}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,3 +36,5 @@ markdown_extensions:
       user: facelessuser
       repo: pymdown-extensions
       normalize_issue_symbols: true
+  - markdown_include.include:
+        base_path: docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ changelog = "https://github.com/pycontribs/subprocess-tee/releases"
 docs = [
   "argparse-manpage",
   "cairosvg",
+  "markdown-include",
   "mkdocs",
   "mkdocs-git-revision-date-localized-plugin",
   "mkdocs-material",


### PR DESCRIPTION
Workaround https://github.com/jdoiro3/mkdocs-multirepo-plugin/issues/57
