### PR TITLE
Make `test_run_string` pass when the default shell is not bash

### DIFF
--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -10,7 +10,7 @@ from subprocess_tee import run
 
 def test_run_string() -> None:
     """Validate run() called with a single string command."""
-    cmd = "echo 111 && >&2 echo 222"
+    cmd = 'bash -c "echo 111 && >&2 echo 222"'
     old_result = subprocess.run(
         cmd,
         shell=True,


### PR DESCRIPTION
My default shell is fish (https://fishshell.com).
`test_run_string` failed on my laptop because the `cmd` was not valid fish syntax.

One option is to find a command which is similar to what was there but works in bash and other shells. Another option, the one I went with, was to always call bash.