### PR TITLE
Remove support for python 3.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
       TOX_PARALLEL_NO_SPINNER: 1
 
     steps:
-      - name: Switch to using Python 3.8 by default
+      - name: Switch to using Python 3.9 by default
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install tox
         run: python3 -m pip install --user tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -19,6 +19,7 @@ jobs:
         id: generate_matrix
         uses: coactions/dynamic-matrix@v1
         with:
+          min_python: "3.9"
           other_names: |
             lint
             docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 # https://peps.python.org/pep-0621/#readme
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 
 name = "subprocess-tee"
@@ -34,7 +34,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -79,7 +78,7 @@ profile = "black"
 known_first_party = "subprocess_tee"
 
 [tool.mypy]
-python_version = 3.8
+python_version = "3.9"
 color_output = true
 error_summary = true
 disallow_any_generics = true


### PR DESCRIPTION
As Python 3.9 reached EOL, we remove support for it.

Related: https://devguide.python.org/versions/
